### PR TITLE
Fix warning

### DIFF
--- a/translate.inc
+++ b/translate.inc
@@ -344,7 +344,7 @@ public OnGameModeInit() {
 	Init();
 	
 	#if defined TRA_OnGameModeInit
-		TRA_OnGameModeInit();
+		return TRA_OnGameModeInit();
 	#else
 		return 1;
 	#endif
@@ -363,12 +363,14 @@ public OnGameModeInit() {
 #endif
 
 // Hook OnJITCompile
-forward OnJITCompile();
+#if !defined _ALS_OnJITCompile
+	forward OnJITCompile();
+#endif
 public OnJITCompile() {
 	Init();
 	
 	#if defined TRA_OnJITCompile
-		TRA_OnJITCompile();
+		return TRA_OnJITCompile();
 	#else
 		return 1;
 	#endif


### PR DESCRIPTION
```
samp-translate\translate.inc:351 (warning) function "OnGameModeInit" should return a value 
samp-translate\translate.inc:366 (warning) state specification on forward declaration is ignored 
```